### PR TITLE
If no recipes are specified in the machine configuration then avoid the processing parameters setup page

### DIFF
--- a/src/routes/MultigridSetup.tsx
+++ b/src/routes/MultigridSetup.tsx
@@ -16,7 +16,7 @@ import { ArrowForwardIcon } from "@chakra-ui/icons";
 
 import { Link as LinkRouter, useLoaderData, useParams } from "react-router-dom";
 import { components } from "schema/main";
-import { setupMultigridWatcher } from "loaders/multigridSetup";
+import { setupMultigridWatcher, startMultigridWatcher } from "loaders/multigridSetup";
 import { getSessionData } from "loaders/session_clients";
 import { SetupStepper } from "components/setupStepper";
 import React, { useEffect } from "react";
@@ -60,6 +60,7 @@ const MultigridSetup = () => {
         } as MultigridWatcherSpec,
         parseInt(sessid),
       );
+      if(!recipesDefined) startMultigridWatcher(parseInt(sessid));
     }
   };
 

--- a/src/routes/MultigridSetup.tsx
+++ b/src/routes/MultigridSetup.tsx
@@ -51,16 +51,16 @@ const MultigridSetup = () => {
 
   const recipesDefined = machineConfig ? machineConfig.recipes ? Object.keys(machineConfig.recipes).length !== 0: false: false;
 
-  const handleSelection = () => {
+  const handleSelection = async () => {
     if (typeof sessid !== "undefined"){
-      setupMultigridWatcher(
+      await setupMultigridWatcher(
         {
           source: selectedDirectory,
           skip_existing_processing: skipExistingProcessing,
         } as MultigridWatcherSpec,
         parseInt(sessid),
       );
-      if(!recipesDefined) startMultigridWatcher(parseInt(sessid));
+      if(!recipesDefined) await startMultigridWatcher(parseInt(sessid));
     }
   };
 

--- a/src/routes/MultigridSetup.tsx
+++ b/src/routes/MultigridSetup.tsx
@@ -49,6 +49,8 @@ const MultigridSetup = () => {
   const handleDirectorySelection = (e: React.ChangeEvent<HTMLSelectElement>) =>
     setSelectedDirectory(e.target.value);
 
+  const recipesDefined = machineConfig ? machineConfig.recipes ? Object.keys(machineConfig.recipes).length !== 0: false: false;
+
   const handleSelection = () => {
     if (typeof sessid !== "undefined"){
       setupMultigridWatcher(
@@ -140,7 +142,7 @@ const MultigridSetup = () => {
                     w={{ base: "100%", md: "19.6%" }}
                     _hover={{ textDecor: "none" }}
                     as={LinkRouter}
-                    to={`../new_session/parameters/${sessid}`}
+                    to={recipesDefined ? `../new_session/parameters/${sessid}`: `../sessions/${sessid}`}
                   >
                     <IconButton
                       aria-label="select"

--- a/src/routes/Session.tsx
+++ b/src/routes/Session.tsx
@@ -257,7 +257,9 @@ const Session = () => {
     setSelectedDirectory(mcfg["data_directories"][0]);
   } 
 
-  useEffect(() => {getSessionProcessingParameterData(sessid).then((params) => {if(params === null) navigate(`/new_session/parameters/${sessid}`);})})
+  const recipesDefined = machineConfig ? machineConfig.recipes ? Object.keys(machineConfig.recipes).length !== 0: false: false;
+
+  useEffect(() => {getSessionProcessingParameterData(sessid).then((params) => {if(params === null && recipesDefined) navigate(`/new_session/parameters/${sessid}`);})})
 
   useEffect(() => {getMachineConfigData().then((mcfg) => handleMachineConfig(mcfg))}, []);
 

--- a/src/routes/SessionSetup.tsx
+++ b/src/routes/SessionSetup.tsx
@@ -63,7 +63,6 @@ const SessionSetup = () => {
         ? 3
         : 0
     : 3;
-  let navigate = useNavigate();
   return (
     <div className="rootContainer">
       <Box w="100%" bg="murfey.50">

--- a/src/routes/SessionSetup.tsx
+++ b/src/routes/SessionSetup.tsx
@@ -1,9 +1,6 @@
 import {
   Button,
   Box,
-  FormControl,
-  FormLabel,
-  Input,
   RadioGroup,
   Radio,
   Stack,
@@ -12,7 +9,7 @@ import {
   Heading,
 } from "@chakra-ui/react";
 import { getForm } from "components/forms";
-import { Link as LinkRouter, useParams, useLoaderData, useNavigate } from "react-router-dom";
+import { Link as LinkRouter, useParams, useLoaderData } from "react-router-dom";
 import { SetupStepper } from "components/setupStepper";
 import { components } from "schema/main";
 import { getProcessingParameterData } from "loaders/processingParameters";


### PR DESCRIPTION
Also stops redirection to that page from session page if session processing parameters do not exist