### PR TITLE
Skip processing

### DIFF
--- a/src/loaders/multigridSetup.tsx
+++ b/src/loaders/multigridSetup.tsx
@@ -22,32 +22,16 @@ export const setupMultigridWatcher = async (
 
 export const startMultigridWatcher = async (
   sessionId: number,
-  process: boolean = true,
 ) => {
-  if(process){
-    const response = await client.post(
-      `sessions/${sessionId}/start_multigrid_watcher`,
-      {},
-    );
+  const response = await client.post(
+    `sessions/${sessionId}/start_multigrid_watcher`,
+    {},
+  );
 
-    if (response.status !== 200) {
-      return null;
-    }
-  
-    return response.data;
-  }
-  else{
-    const response = await client.post(
-      `sessions/${sessionId}/start_multigrid_watcher?process=false`,
-      {},
-    );
-
-    if (response.status !== 200) {
-      return null;
-    }
-  
-    return response.data;
+  if (response.status !== 200) {
+    return null;
   }
 
-  return null;
+  return response.data;
+
 };

--- a/src/loaders/multigridSetup.tsx
+++ b/src/loaders/multigridSetup.tsx
@@ -22,15 +22,32 @@ export const setupMultigridWatcher = async (
 
 export const startMultigridWatcher = async (
   sessionId: number,
+  process: boolean = true,
 ) => {
-  const response = await client.post(
-    `sessions/${sessionId}/start_multigrid_watcher`,
-    {},
-  );
+  if(process){
+    const response = await client.post(
+      `sessions/${sessionId}/start_multigrid_watcher`,
+      {},
+    );
 
-  if (response.status !== 200) {
-    return null;
+    if (response.status !== 200) {
+      return null;
+    }
+  
+    return response.data;
+  }
+  else{
+    const response = await client.post(
+      `sessions/${sessionId}/start_multigrid_watcher?process=false`,
+      {},
+    );
+
+    if (response.status !== 200) {
+      return null;
+    }
+  
+    return response.data;
   }
 
-  return response.data;
+  return null;
 };

--- a/src/loaders/sessionSetup.tsx
+++ b/src/loaders/sessionSetup.tsx
@@ -19,4 +19,3 @@ export const registerProcessingParameters = async (
 
   return response.data;
 };
-

--- a/src/loaders/session_clients.tsx
+++ b/src/loaders/session_clients.tsx
@@ -72,6 +72,17 @@ export const createSession = async (visit: string, sessionName: string, instrume
   return response.data;
 };
 
+export const updateSession = async (sessionID: number, process: boolean = true) => {
+  const response = await client.post(
+    `sessions/${sessionID}?process=${process ? 'true': 'false'}`,
+    {},
+  );
+  if (response.status !== 200) {
+    return null;
+  }
+  return response.data;
+}
+
 export const deleteSessionData = async (sessid: number) => {
   const response = await client.delete(`sessions/${sessid}`);
   if (response.status !== 200) {

--- a/src/routes/MultigridSetup.tsx
+++ b/src/routes/MultigridSetup.tsx
@@ -16,7 +16,7 @@ import { ArrowForwardIcon } from "@chakra-ui/icons";
 
 import { Link as LinkRouter, useLoaderData, useParams } from "react-router-dom";
 import { components } from "schema/main";
-import { setupMultigridWatcher } from "loaders/multigridSetup";
+import { setupMultigridWatcher, startMultigridWatcher } from "loaders/multigridSetup";
 import { getSessionData } from "loaders/session_clients";
 import { SetupStepper } from "components/setupStepper";
 import React, { useEffect } from "react";
@@ -60,6 +60,7 @@ const MultigridSetup = () => {
         } as MultigridWatcherSpec,
         parseInt(sessid),
       );
+      if(!recipesDefined) startMultigridWatcher(parseInt(sessid));
     }
   };
 

--- a/src/routes/MultigridSetup.tsx
+++ b/src/routes/MultigridSetup.tsx
@@ -51,16 +51,16 @@ const MultigridSetup = () => {
 
   const recipesDefined = machineConfig ? machineConfig.recipes ? Object.keys(machineConfig.recipes).length !== 0: false: false;
 
-  const handleSelection = () => {
+  const handleSelection = async () => {
     if (typeof sessid !== "undefined"){
-      setupMultigridWatcher(
+      await setupMultigridWatcher(
         {
           source: selectedDirectory,
           skip_existing_processing: skipExistingProcessing,
         } as MultigridWatcherSpec,
         parseInt(sessid),
       );
-      if(!recipesDefined) startMultigridWatcher(parseInt(sessid));
+      if(!recipesDefined) await startMultigridWatcher(parseInt(sessid));
     }
   };
 

--- a/src/routes/MultigridSetup.tsx
+++ b/src/routes/MultigridSetup.tsx
@@ -49,6 +49,8 @@ const MultigridSetup = () => {
   const handleDirectorySelection = (e: React.ChangeEvent<HTMLSelectElement>) =>
     setSelectedDirectory(e.target.value);
 
+  const recipesDefined = machineConfig ? machineConfig.recipes ? Object.keys(machineConfig.recipes).length !== 0: false: false;
+
   const handleSelection = () => {
     if (typeof sessid !== "undefined"){
       setupMultigridWatcher(
@@ -140,7 +142,7 @@ const MultigridSetup = () => {
                     w={{ base: "100%", md: "19.6%" }}
                     _hover={{ textDecor: "none" }}
                     as={LinkRouter}
-                    to={`../new_session/parameters/${sessid}`}
+                    to={recipesDefined ? `../new_session/parameters/${sessid}`: `../sessions/${sessid}`}
                   >
                     <IconButton
                       aria-label="select"

--- a/src/routes/Session.tsx
+++ b/src/routes/Session.tsx
@@ -257,7 +257,9 @@ const Session = () => {
     setSelectedDirectory(mcfg["data_directories"][0]);
   } 
 
-  useEffect(() => {getSessionProcessingParameterData(sessid).then((params) => {if(params === null) navigate(`/new_session/parameters/${sessid}`);})})
+  const recipesDefined = machineConfig ? machineConfig.recipes ? Object.keys(machineConfig.recipes).length !== 0: false: false;
+
+  useEffect(() => {getSessionProcessingParameterData(sessid).then((params) => {if(params === null && recipesDefined) navigate(`/new_session/parameters/${sessid}`);})})
 
   useEffect(() => {getMachineConfigData().then((mcfg) => handleMachineConfig(mcfg))}, []);
 

--- a/src/routes/Session.tsx
+++ b/src/routes/Session.tsx
@@ -257,16 +257,16 @@ const Session = () => {
     setSelectedDirectory(mcfg["data_directories"][0]);
   } 
 
-  const recipesDefined = machineConfig ? machineConfig.recipes ? Object.keys(machineConfig.recipes).length !== 0: false: false;
-
-  useEffect(() => {getSessionProcessingParameterData(sessid).then((params) => {if(params === null && recipesDefined) navigate(`/new_session/parameters/${sessid}`);})})
-
-  useEffect(() => {getMachineConfigData().then((mcfg) => handleMachineConfig(mcfg))}, []);
-
   useEffect(() => {
     getSessionData(sessid).then((sess) => setSession(sess.session));
     setUUID(uuid4());
   }, []);
+
+  const recipesDefined = machineConfig ? machineConfig.recipes ? Object.keys(machineConfig.recipes).length !== 0: false: false;
+
+  useEffect(() => {getSessionProcessingParameterData(sessid).then((params) => {if(params === null && recipesDefined && session !== undefined && session.process) navigate(`/new_session/parameters/${sessid}`);})})
+
+  useEffect(() => {getMachineConfigData().then((mcfg) => handleMachineConfig(mcfg))}, []);
 
   const parseWebsocketMessage = (message: any) => {
     let parsedMessage: any = {};

--- a/src/routes/SessionSetup.tsx
+++ b/src/routes/SessionSetup.tsx
@@ -49,9 +49,9 @@ const SessionSetup = () => {
     }
   };
 
-  const handleSkip = () => {
+  const handleSkip = async () => {
     if (sessid !== undefined){
-      updateSession(parseInt(sessid), false);
+      await updateSession(parseInt(sessid), false);
       startMultigridWatcher(parseInt(sessid));
     }
   }

--- a/src/routes/SessionSetup.tsx
+++ b/src/routes/SessionSetup.tsx
@@ -148,7 +148,7 @@ const SessionSetup = () => {
               as={LinkRouter}
               to={`../sessions/${sessid}`}
             >
-              <Button onClick={handleSkip}>Skip</Button>
+              <Button onClick={handleSkip}>Disable Processing</Button>
             </Link>
           </Box>
         </Stack>

--- a/src/routes/SessionSetup.tsx
+++ b/src/routes/SessionSetup.tsx
@@ -63,7 +63,6 @@ const SessionSetup = () => {
         ? 3
         : 0
     : 3;
-  let navigate = useNavigate();
   return (
     <div className="rootContainer">
       <Box w="100%" bg="murfey.50">

--- a/src/routes/SessionSetup.tsx
+++ b/src/routes/SessionSetup.tsx
@@ -14,7 +14,7 @@ import { SetupStepper } from "components/setupStepper";
 import { components } from "schema/main";
 import { getProcessingParameterData } from "loaders/processingParameters";
 import { startMultigridWatcher } from "loaders/multigridSetup";
-import { getSessionData } from "loaders/session_clients";
+import { getSessionData, updateSession } from "loaders/session_clients";
 import { registerProcessingParameters } from "loaders/sessionSetup";
 
 import React, { useEffect } from "react";
@@ -48,6 +48,13 @@ const SessionSetup = () => {
       setParamsSet(true);
     }
   };
+
+  const handleSkip = () => {
+    if (sessid !== undefined){
+      updateSession(parseInt(sessid), false);
+      startMultigridWatcher(parseInt(sessid));
+    }
+  }
 
   if (session)
     getProcessingParameterData(session.session.id.toString()).then((params) =>
@@ -141,7 +148,7 @@ const SessionSetup = () => {
               as={LinkRouter}
               to={`../sessions/${sessid}`}
             >
-              <Button onClick={() => sessid !== undefined ? startMultigridWatcher(parseInt(sessid), false): null}>Skip</Button>
+              <Button onClick={handleSkip}>Skip</Button>
             </Link>
           </Box>
         </Stack>

--- a/src/routes/SessionSetup.tsx
+++ b/src/routes/SessionSetup.tsx
@@ -1,9 +1,6 @@
 import {
   Button,
   Box,
-  FormControl,
-  FormLabel,
-  Input,
   RadioGroup,
   Radio,
   Stack,
@@ -12,7 +9,7 @@ import {
   Heading,
 } from "@chakra-ui/react";
 import { getForm } from "components/forms";
-import { Link as LinkRouter, useParams, useLoaderData, useNavigate } from "react-router-dom";
+import { Link as LinkRouter, useParams, useLoaderData } from "react-router-dom";
 import { SetupStepper } from "components/setupStepper";
 import { components } from "schema/main";
 import { getProcessingParameterData } from "loaders/processingParameters";

--- a/src/routes/SessionSetup.tsx
+++ b/src/routes/SessionSetup.tsx
@@ -141,7 +141,7 @@ const SessionSetup = () => {
               as={LinkRouter}
               to={`../sessions/${sessid}`}
             >
-              <Button>Skip</Button>
+              <Button onClick={() => sessid !== undefined ? startMultigridWatcher(parseInt(sessid), false): null}>Skip</Button>
             </Link>
           </Box>
         </Stack>

--- a/src/schema/main.ts
+++ b/src/schema/main.ts
@@ -1833,6 +1833,11 @@ export interface components {
        * @default
        */
       instrument_name?: string;
+      /**
+       * Process
+       * @default
+       */
+      process?: boolean;
     };
     /** SessionClients */
     SessionClients: {


### PR DESCRIPTION
This PR is built on top of PR #21, so merging this will cover both PRs.

* If no recipes are present in the machine configuration, the frontend should not prompt users to provide processing parameters. 
* The call to set up the multigrid watcher needs to be awaited in order to avoid a race condition where the request to start the watcher is sent before it's fully set.
* Enabled the "Skip Processing" button that will disable processing for this session. This coincides with PR ([#590](https://github.com/DiamondLightSource/python-murfey/pull/590)) in the main Murfey repository.