### PR TITLE
Fix broken URL paths

### DIFF
--- a/src/loaders/jwt.tsx
+++ b/src/loaders/jwt.tsx
@@ -10,7 +10,7 @@ export const getJWT = async (loginDetails: LoginDetails) => {
   formData.append("username", loginDetails.username);
   formData.append("password", loginDetails.password);
 
-  const response = await client.post(`token`, formData);
+  const response = await client.post(`auth/token`, formData);
   if (response.status !== 200) {
     return null;
   }

--- a/src/loaders/possibleGainRefs.tsx
+++ b/src/loaders/possibleGainRefs.tsx
@@ -32,7 +32,7 @@ export const prepareGainReference = async (
   eer: boolean = false,
   tag: string = "",
 ) => {
-  const response = await client.post(`file_manipulation/sessions/${sessionId}/process_gain`, {
+  const response = await client.post(`file_io/frontend/sessions/${sessionId}/process_gain`, {
     gain_ref: gainRef,
     rescale: rescale,
     eer: eer,

--- a/src/schema/main.ts
+++ b/src/schema/main.ts
@@ -541,15 +541,15 @@ export interface paths {
     /** Get Cryolo Model Path */
     get: operations["get_cryolo_model_path_sessions__session_id__cryolo_model_get"];
   };
-  "/token": {
+  "auth/token": {
     /** Generate Token */
     post: operations["generate_token_token_post"];
   };
-  "/sessions/{session_id}/token": {
+  "auth/sessions/{session_id}/token": {
     /** Mint Session Token */
     get: operations["mint_session_token_sessions__session_id__token_get"];
   };
-  "/validate_token": {
+  "auth/validate_token": {
     /** Simple Token Validation */
     get: operations["simple_token_validation_validate_token_get"];
   };


### PR DESCRIPTION
As part of tightening security, the client and frontend use different authentication methods when interacting with the backend server and will need to poke different endpoints to do so.

This PR works in conjunction with PR [#601](https://github.com/DiamondLightSource/python-murfey/pull/601) in Murfey to expose a new endpoint for the frontend to request gain reference processing through.