### PR TITLE
Standardise file and folder permissions when building app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,11 @@ COPY ./package.json ./yarn.lock ./
 RUN yarn install --immutable --check-cache
 
 # Copy across files needed to build the app and build it
+# Standardise permissions to account for different default permissions between devs
 COPY ./ ./
-RUN yarn build
+RUN yarn build && \
+    chmod -R o+r /usr/src/app/build && \
+    find /usr/src/app/build -type d -exec chmod o+rx {} +
 
 # Start second stage
 FROM docker.io/nginxinc/nginx-unprivileged:alpine3.21-slim


### PR DESCRIPTION
This accounts for discrepancies in default permissions between developers, which potentially prevent certain files from being read and rendered.