### PR TITLE
Consistent naming of routers as sessions not session

### DIFF
--- a/src/loaders/sessionClients.tsx
+++ b/src/loaders/sessionClients.tsx
@@ -30,7 +30,7 @@ export const getSessionDataForVisit = async (
 }
 
 export const getSessionData = async (sessid: string = '0') => {
-  const response = await client.get(`session_info/session/${sessid}`)
+  const response = await client.get(`session_info/sessions/${sessid}`)
 
   if (response.status !== 200) return null
   // Convert naive times into UTC, if set
@@ -45,20 +45,6 @@ export const getSessionData = async (sessid: string = '0') => {
   return response.data
 }
 
-export const linkSessionToClient = async (
-  client_id: number,
-  sessionName: string
-) => {
-  const response = await client.post(
-    `session_info/clients/${client_id}/session`,
-    {
-      session_name: sessionName,
-    }
-  )
-  if (response.status !== 200) return null
-  return response.data
-}
-
 export const createSession = async (
   visit: string,
   sessionName: string,
@@ -69,7 +55,7 @@ export const createSession = async (
     ? convertUTCToUKNaive(sessionEndTime.toISOString())
     : null
   const response = await client.post(
-    `session_info/instruments/${instrumentName}/visits/${visit}/session/${sessionName}`,
+    `session_info/instruments/${instrumentName}/visits/${visit}/sessions/${sessionName}`,
     { end_time: ukEndTime }
   )
   if (response.status !== 200) return null

--- a/src/schema/main.ts
+++ b/src/schema/main.ts
@@ -68,7 +68,7 @@ export interface paths {
     /** Get Rsyncers For Client */
     get: operations['get_rsyncers_for_client_clients__client_id__rsyncers_get']
   }
-  '/session/{session_id}': {
+  '/sessions/{session_id}': {
     /** Get Session */
     get: operations['get_session_session__session_id__get']
   }
@@ -262,7 +262,7 @@ export interface paths {
     /** Failed Client Post */
     post: operations['failed_client_post_failed_client_post_post']
   }
-  '/instruments/{instrument_name}/visits/{visit}/session/{name}': {
+  '/instruments/{instrument_name}/visits/{visit}/sessions/{name}': {
     /** Create Session */
     post: operations['create_session_instruments__instrument_name__visits__visit__session__name__post']
   }


### PR DESCRIPTION
Also removes a router that points to a non-existent endpoint