### PR TITLE
Add buttons to turn off/on alerts

### DIFF
--- a/src/loaders/alertManager.tsx
+++ b/src/loaders/alertManager.tsx
@@ -39,43 +39,33 @@ export const createSilence = async (
 }
 
 export const getSilences = async (instrumentName: string) => {
-  //for testing
-  instrumentName = 'm00'
+  instrumentName = 'm00' //for testing
   const response = await client.get(`session_info/silences/${instrumentName}`)
-  //   console.log(response.status)
-  //   console.log(response.data)
-  //   console.log(response)
   if (response.status !== 200) {
     return null
   }
-  //   console.log(response.data.replace(/'/ig,'"'))
-  //   console.log(JSON.parse(response.data.replace(/'/ig,'"')))
-  response.data = response.data.replaceAll('True', 'true')
-  response.data = response.data.replaceAll('False', 'false')
-  //   console.log(response.data)
-  let silences: Silence[] = JSON.parse(response.data.replace(/'/gi, '"'))
-  //   console.log(silences)
-  //   console.log(silences[2])
+  let silences: Silence[] = response.data
   const activeSilences: Silence[] = silences.filter(
     (item: Silence) => item.status.state == 'active'
   )
-  //   console.log(activeSilences)
-  //   console.log(activeSilences[0].endsAt)
-
   return activeSilences
 }
 
 export const getLongestSilence = async (instrumentName: string) => {
   const activeSilences: Silence[] | null = await getSilences(instrumentName)
   if (activeSilences == null || activeSilences.length == 0) return null
-
   const longestSilence = activeSilences.reduce((a, b) =>
     a.endsAt > b.endsAt ? a : b
   )
-  console.log(longestSilence)
-
-  //   new Date(Math.max.apply(null, activeSilences.map(function(e) {
-  //     return new Date(e.endsAt)
-  //   })))
   return longestSilence
+}
+
+export const deleteSilence = async (instrumentName: string) => {
+  const response = await client.delete(
+    `session_info/silences/${instrumentName}`
+  )
+  if (response.status !== 200) {
+    return null
+  }
+  return response.data
 }

--- a/src/loaders/alertManager.tsx
+++ b/src/loaders/alertManager.tsx
@@ -1,0 +1,18 @@
+import { client } from 'utils/api/client'
+
+export const createSilence = async (
+  instrumentName: string,
+  proposedEndTime: Date
+) => {
+  const response = await client.post(
+    `session_info/silences/${instrumentName}?end_time=${proposedEndTime.toISOString()}`,
+    {}
+  )
+  console.log(response.status)
+  console.log(response.data)
+  console.log(response)
+  if (response.status !== 200) {
+    return null
+  }
+  return response.data
+}

--- a/src/loaders/alertManager.tsx
+++ b/src/loaders/alertManager.tsx
@@ -1,5 +1,26 @@
 import { client } from 'utils/api/client'
 
+type Matcher = {
+  isEqual: string
+  isRegex: string
+  name: string
+  value: string
+}
+type Status = {
+  state: string
+}
+
+export type Silence = {
+  id: string
+  status: Status
+  updatedAt: string
+  comment: string
+  createdBy: string
+  endsAt: Date
+  matchers: Matcher[]
+  startsAt: string
+}
+
 export const createSilence = async (
   instrumentName: string,
   proposedEndTime: Date
@@ -15,4 +36,46 @@ export const createSilence = async (
     return null
   }
   return response.data
+}
+
+export const getSilences = async (instrumentName: string) => {
+  //for testing
+  instrumentName = 'm00'
+  const response = await client.get(`session_info/silences/${instrumentName}`)
+  //   console.log(response.status)
+  //   console.log(response.data)
+  //   console.log(response)
+  if (response.status !== 200) {
+    return null
+  }
+  //   console.log(response.data.replace(/'/ig,'"'))
+  //   console.log(JSON.parse(response.data.replace(/'/ig,'"')))
+  response.data = response.data.replaceAll('True', 'true')
+  response.data = response.data.replaceAll('False', 'false')
+  //   console.log(response.data)
+  let silences: Silence[] = JSON.parse(response.data.replace(/'/gi, '"'))
+  //   console.log(silences)
+  //   console.log(silences[2])
+  const activeSilences: Silence[] = silences.filter(
+    (item: Silence) => item.status.state == 'active'
+  )
+  //   console.log(activeSilences)
+  //   console.log(activeSilences[0].endsAt)
+
+  return activeSilences
+}
+
+export const getLongestSilence = async (instrumentName: string) => {
+  const activeSilences: Silence[] | null = await getSilences(instrumentName)
+  if (activeSilences == null || activeSilences.length == 0) return null
+
+  const longestSilence = activeSilences.reduce((a, b) =>
+    a.endsAt > b.endsAt ? a : b
+  )
+  console.log(longestSilence)
+
+  //   new Date(Math.max.apply(null, activeSilences.map(function(e) {
+  //     return new Date(e.endsAt)
+  //   })))
+  return longestSilence
 }

--- a/src/loaders/alertManager.tsx
+++ b/src/loaders/alertManager.tsx
@@ -40,15 +40,12 @@ export const createSilence = async (
 
 export const getSilences = async (instrumentName: string) => {
   instrumentName = 'm00' //for testing
-  const response = await client.get(`session_info/silences/${instrumentName}`)
+  const response = await client.get(`session_info/silences/${instrumentName}`) //should return active silences
   if (response.status !== 200) {
     return null
   }
   let silences: Silence[] = response.data
-  const activeSilences: Silence[] = silences.filter(
-    (item: Silence) => item.status.state == 'active'
-  )
-  return activeSilences
+  return silences
 }
 
 export const getLongestSilence = async (instrumentName: string) => {

--- a/src/loaders/alertManager.tsx
+++ b/src/loaders/alertManager.tsx
@@ -29,9 +29,6 @@ export const createSilence = async (
     `session_info/silences/${instrumentName}?end_time=${proposedEndTime.toISOString()}`,
     {}
   )
-  console.log(response.status)
-  console.log(response.data)
-  console.log(response)
   if (response.status !== 200) {
     return null
   }
@@ -39,7 +36,6 @@ export const createSilence = async (
 }
 
 export const getSilences = async (instrumentName: string) => {
-  instrumentName = 'm00' //for testing
   const response = await client.get(`session_info/silences/${instrumentName}`) //should return active silences
   if (response.status !== 200) {
     return null
@@ -50,7 +46,7 @@ export const getSilences = async (instrumentName: string) => {
 
 export const getLongestSilence = async (instrumentName: string) => {
   const activeSilences: Silence[] | null = await getSilences(instrumentName)
-  if (activeSilences == null || activeSilences.length == 0) return null
+  if (activeSilences === null || activeSilences.length === 0) return null
   const longestSilence = activeSilences.reduce((a, b) =>
     a.endsAt > b.endsAt ? a : b
   )

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -14,19 +14,27 @@ import {
   useDisclosure,
   ModalBody,
   Text,
+  VStack,
+  Card,
+  CardBody,
+  HStack,
+  Tooltip,
+  IconButton,
 } from '@chakra-ui/react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { InstrumentCard } from 'components/instrumentCard'
 import { SessionRow } from 'components/sessionRow'
+import { createSilence } from 'loaders/alertManager'
 import { getInstrumentConnectionStatus } from 'loaders/general'
 import { sessionTokenCheck } from 'loaders/jwt'
 import { finaliseSession } from 'loaders/rsyncers'
 import { getAllSessionsData } from 'loaders/sessionClients'
 import { checkMultigridControllerStatus } from 'loaders/sessionSetup'
 import React, { useEffect } from 'react'
+import { FaCalendar } from 'react-icons/fa'
 import { useNavigate, useLoaderData } from 'react-router-dom'
 import { components } from 'schema/main'
-import { convertUKNaiveToUTC } from 'utils/generic'
+import { convertUKNaiveToUTC, convertUTCToUKNaive } from 'utils/generic'
 
 type Session = components['schemas']['Session']
 type ExpandedSession = Session & {
@@ -167,6 +175,41 @@ export const Home = () => {
     onCloseVisitCleanupPrompt()
     navigate(`../instruments/${instrumentName}/new_session`)
   }
+  // Create Silence values and logic
+  const {
+    isOpen: isOpenCalendar,
+    onOpen: onOpenCalendar,
+    onClose: onCloseCalendar,
+  } = useDisclosure()
+
+  const [endTime, setEndTime] = React.useState<Date | null>(null)
+  const [proposedEndTime, setProposedEndTime] = React.useState<Date | null>(
+    null
+  )
+  // Upon initialisation, zero out seconds field
+  const defaultVisitEndTime = (() => {
+    let now = new Date()
+    let timestamp = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate(),
+      now.getHours(),
+      now.getMinutes(),
+      0, // Set seconds to 0
+      0 // Set milliseconds to 0
+    ).toISOString()
+    return timestamp
+  })()
+
+  const handleCreateSilence = (
+    microscope: string | null,
+    proposedEndTime: Date | null
+  ) => {
+    console.log(microscope)
+    console.log(proposedEndTime)
+    if (microscope == null || proposedEndTime == null) return null
+    createSilence(microscope, proposedEndTime)
+  }
 
   // Page rendering logic below here
   if (isLoading) return <p>Loading sessions...</p>
@@ -222,6 +265,54 @@ export const Home = () => {
                 Skip Cleanup
               </Button>
               <Button variant="default" onClick={handleVisitCleanupPrompt}>
+                Confirm
+              </Button>
+            </ModalFooter>
+          </ModalContent>
+        </Modal>
+        <Modal isOpen={isOpenCalendar} onClose={onCloseCalendar} size={'xl'}>
+          <ModalOverlay />
+          <ModalContent>
+            <ModalHeader>Select Silence End Time</ModalHeader>
+            <ModalCloseButton />
+            <ModalBody>
+              <input
+                aria-label="Date and time"
+                type="datetime-local"
+                // Convert UTC into local UK time, and set seconds to 0
+                defaultValue={
+                  convertUTCToUKNaive(defaultVisitEndTime).slice(0, 16) + ':00'
+                }
+                onChange={(e) => {
+                  // The seconds field is removed when it's 0, so add it back
+                  let timestamp = e.target.value
+                  timestamp += ':00'
+                  // Find the equivalent UTC time and save that
+                  let newEndTime = new Date(convertUKNaiveToUTC(timestamp))
+                  setProposedEndTime(newEndTime)
+                }}
+              />
+            </ModalBody>
+            <ModalFooter>
+              <Button
+                variant="ghost"
+                mr={3}
+                onClick={() => {
+                  onCloseCalendar()
+                  setProposedEndTime(null)
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="default"
+                onClick={() => {
+                  if (proposedEndTime) {
+                    setEndTime(proposedEndTime)
+                    onCloseCalendar()
+                  }
+                }}
+              >
                 Confirm
               </Button>
             </ModalFooter>
@@ -321,9 +412,54 @@ export const Home = () => {
             )}
           </Box>
           {/* Right column showing instrument card */}
-          <Box minW="400px" maxW="600px" flex="1" overflow="auto">
-            <InstrumentCard />
-          </Box>
+          <VStack>
+            <Box minW="400px" maxW="600px" flex="1" overflow="auto">
+              <InstrumentCard />
+            </Box>
+            <Card>
+              <CardBody>
+                <HStack>
+                  <VStack>
+                    <Text>Silence alerts until</Text>
+                    <Text>
+                      {endTime
+                        ? new Intl.DateTimeFormat('en-GB', {
+                            timeZone: 'Europe/London',
+                            weekday: 'short',
+                            year: 'numeric',
+                            month: 'short',
+                            day: '2-digit',
+                            hour: '2-digit',
+                            minute: '2-digit',
+                            second: '2-digit',
+                            timeZoneName: 'short',
+                            hour12: false,
+                          }).format(endTime)
+                        : 'NOT SET'}
+                    </Text>
+                  </VStack>
+                  <Tooltip label="Set end time for silence">
+                    <IconButton
+                      aria-label="calendar-for-end-time"
+                      onClick={() => onOpenCalendar()}
+                    >
+                      <FaCalendar />
+                    </IconButton>
+                  </Tooltip>
+                  <Button
+                    variant="default"
+                    isDisabled={proposedEndTime ? false : true}
+                    onClick={() => {
+                      console.log(instrumentName)
+                      handleCreateSilence(instrumentName, proposedEndTime)
+                    }}
+                  >
+                    Silence Alerts
+                  </Button>
+                </HStack>
+              </CardBody>
+            </Card>
+          </VStack>
         </Box>
       </Box>
     </div>

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -28,6 +28,7 @@ import { InstrumentCard } from 'components/instrumentCard'
 import { SessionRow } from 'components/sessionRow'
 import {
   createSilence,
+  deleteSilence,
   getLongestSilence,
   getSilences,
   Silence,
@@ -196,28 +197,28 @@ export const Home = () => {
   const [proposedEndTime, setProposedEndTime] = React.useState<Date | null>(
     null
   ) //whilst date being picked
-  const [activeSilences, setActiveSilences] = React.useState<Silence | null>(
-    null
-  )
-
+  const [activeSilence, setActiveSilence] = React.useState<Silence | null>(null)
+  //when page loads, find longest active silence. Find again when a new silence is addeds
+  const getActiveSilence = async () => {
+    const silence: Silence | null = await getLongestSilence(
+      instrumentName ? instrumentName : ''
+    )
+    if (silence == null) {
+      setActiveSilence(null)
+      setExistingEndTime(null)
+      return null
+    }
+    setActiveSilence(silence)
+    setExistingEndTime(new Date(silence.endsAt))
+  }
+  //find active silence on loads
   useEffect(() => {
     if (!sessionsData) return
-    const getActiveSilences = async () => {
-      const silences = await getLongestSilence(
-        instrumentName ? instrumentName : ''
-      )
-
-      if (silences == null) return false
-      setActiveSilences(silences)
-      const newEndTime = new Date(silences.endsAt)
-      console.log(newEndTime)
-      setExistingEndTime(newEndTime)
-    }
-    getActiveSilences()
-  }, [endTime])
+    getActiveSilence()
+  }, [])
 
   // Upon initialisation, zero out seconds field
-  const defaultVisitEndTime = (() => {
+  const defaultSilenceEndTime = (() => {
     let now = new Date()
     let timestamp = new Date(
       now.getFullYear(),
@@ -231,17 +232,21 @@ export const Home = () => {
     return timestamp
   })()
 
-  const handleCreateSilence = (
+  const handleCreateSilence = async (
     microscope: string | null,
     proposedEndTime: Date | null
   ) => {
-    console.log(microscope)
-    console.log(proposedEndTime)
     if (microscope == null || proposedEndTime == null) return null
-    createSilence(microscope, proposedEndTime)
+    await createSilence(microscope, proposedEndTime)
+    getActiveSilence() //find which is the longest silence
     setEndTime(null)
   }
-
+  const handleDeleteSilence = async (microscope: string | null) => {
+    if (microscope == null) return null
+    await deleteSilence(microscope)
+    getActiveSilence() //reset active silences to null
+    setEndTime(null)
+  }
   // Page rendering logic below here
   if (isLoading) return <p>Loading sessions...</p>
   if (isError || !data) return <p>Failed to load sessions.</p>
@@ -313,7 +318,8 @@ export const Home = () => {
                 type="datetime-local"
                 // Convert UTC into local UK time, and set seconds to 0
                 defaultValue={
-                  convertUTCToUKNaive(defaultVisitEndTime).slice(0, 16) + ':00'
+                  convertUTCToUKNaive(defaultSilenceEndTime).slice(0, 16) +
+                  ':00'
                 }
                 onChange={(e) => {
                   // The seconds field is removed when it's 0, so add it back
@@ -452,7 +458,7 @@ export const Home = () => {
               <CardBody>
                 <VStack>
                   <VStack>
-                    <Text>{activeSilences ? 'Alerts Silenced Until' : ''}</Text>
+                    <Text>{activeSilence ? 'Alerts Silenced Until' : ''}</Text>
                     <Text>
                       {existingEndTime
                         ? new Intl.DateTimeFormat('en-GB', {
@@ -469,6 +475,21 @@ export const Home = () => {
                           }).format(existingEndTime)
                         : ''}
                     </Text>
+                    {existingEndTime ? (
+                      <Button
+                        variant="default"
+                        isActive={existingEndTime ? false : true}
+                        isDisabled={existingEndTime ? false : true}
+                        onClick={() => {
+                          console.log('delete silence clicked' + instrumentName)
+                          handleDeleteSilence(instrumentName)
+                        }}
+                      >
+                        Delete Silence
+                      </Button>
+                    ) : (
+                      ''
+                    )}
                     <Text>Silence alerts until</Text>
                     <Text>
                       {endTime
@@ -498,10 +519,10 @@ export const Home = () => {
                     </Tooltip>
                     <Button
                       variant="default"
-                      isDisabled={proposedEndTime ? false : true}
+                      isDisabled={endTime ? false : true}
                       onClick={() => {
                         console.log(instrumentName)
-                        handleCreateSilence(instrumentName, proposedEndTime)
+                        handleCreateSilence(instrumentName, endTime)
                       }}
                     >
                       Silence Alerts

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -35,7 +35,7 @@ import { sessionTokenCheck } from 'loaders/jwt'
 import { finaliseSession } from 'loaders/rsyncers'
 import { getAllSessionsData } from 'loaders/sessionClients'
 import { checkMultigridControllerStatus } from 'loaders/sessionSetup'
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { FaCalendar } from 'react-icons/fa'
 import { useNavigate, useLoaderData } from 'react-router-dom'
 import { components } from 'schema/main'
@@ -203,24 +203,22 @@ export const Home = () => {
   ) //whilst date being chosen
 
   //find longest existing silence and set existing end time
-  const checkExistingEndTime = async () => {
+  const checkExistingEndTime = useCallback(async () => {
     const silence: Silence | null = await getLongestSilence(
       instrumentName ? instrumentName : ''
     )
     if (silence == null) {
       setExistingEndTime(null)
-      // return null
     } else {
       const existingEndsAt = new Date(silence.endsAt)
       setExistingEndTime(existingEndsAt)
     }
-    // return existingEndsAt
-  }
+  }, [instrumentName])
 
   //on load, find and set longest active silence end time
   useEffect(() => {
     checkExistingEndTime()
-  }, [])
+  }, [checkExistingEndTime])
 
   // Upon initialisation, zero out seconds field for calendar date/time picker
   const defaultSilenceEndTime = (() => {
@@ -314,7 +312,6 @@ export const Home = () => {
         </Modal>
         <Modal isOpen={isOpenCalendar} onClose={onCloseCalendar} size={'xl'}>
           <ModalOverlay />
-          9T09:43:00.000Z
           <ModalContent>
             <ModalHeader>Turn off alerts until (select time)</ModalHeader>
             <ModalCloseButton />

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -312,7 +312,7 @@ export const Home = () => {
           <ModalOverlay />
           9T09:43:00.000Z
           <ModalContent>
-            <ModalHeader>Select Silence End Time</ModalHeader>
+            <ModalHeader>Turn off alerts until (select time)</ModalHeader>
             <ModalCloseButton />
             <ModalBody>
               <input
@@ -460,8 +460,8 @@ export const Home = () => {
               <CardBody>
                 <VStack>
                   <VStack>
-                    <Text>{activeSilence ? 'Alerts Silenced Until' : ''}</Text>
                     <Text>
+                      {activeSilence ? 'Alerts off until ' : ''}
                       {existingEndTime
                         ? new Intl.DateTimeFormat('en-GB', {
                             timeZone: 'Europe/London',
@@ -487,38 +487,41 @@ export const Home = () => {
                           handleDeleteSilence(instrumentName)
                         }}
                       >
-                        Delete Silence
+                        Turn On Alerts
                       </Button>
                     ) : (
                       ''
                     )}
-                    <Text>Silence alerts until</Text>
-                    <Text>
-                      {endTime
-                        ? new Intl.DateTimeFormat('en-GB', {
-                            timeZone: 'Europe/London',
-                            weekday: 'short',
-                            year: 'numeric',
-                            month: 'short',
-                            day: '2-digit',
-                            hour: '2-digit',
-                            minute: '2-digit',
-                            second: '2-digit',
-                            timeZoneName: 'short',
-                            hour12: false,
-                          }).format(endTime)
-                        : 'NOT SET'}
-                    </Text>
+                    <Text>Turn off alerts until</Text>
+                    <HStack>
+                      <Text>
+                        {endTime
+                          ? new Intl.DateTimeFormat('en-GB', {
+                              timeZone: 'Europe/London',
+                              weekday: 'short',
+                              year: 'numeric',
+                              month: 'short',
+                              day: '2-digit',
+                              hour: '2-digit',
+                              minute: '2-digit',
+                              second: '2-digit',
+                              timeZoneName: 'short',
+                              hour12: false,
+                            }).format(endTime)
+                          : 'NOT SET'}
+                      </Text>
+                      <Tooltip label="Set end time for silence">
+                        <IconButton
+                          aria-label="calendar-for-end-time"
+                          onClick={() => onOpenCalendar()}
+                        >
+                          <FaCalendar />
+                        </IconButton>
+                      </Tooltip>
+                    </HStack>
                   </VStack>
+
                   <HStack>
-                    <Tooltip label="Set end time for silence">
-                      <IconButton
-                        aria-label="calendar-for-end-time"
-                        onClick={() => onOpenCalendar()}
-                      >
-                        <FaCalendar />
-                      </IconButton>
-                    </Tooltip>
                     <Button
                       variant="default"
                       isDisabled={endTime ? false : true}
@@ -527,7 +530,7 @@ export const Home = () => {
                         handleCreateSilence(instrumentName, endTime)
                       }}
                     >
-                      Silence Alerts
+                      Turn Off Alerts
                     </Button>
                   </HStack>
                 </VStack>

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,5 +1,3 @@
-import { setSourceMapsEnabled } from 'process'
-
 import {
   Box,
   Button,
@@ -182,7 +180,9 @@ export const Home = () => {
     onCloseVisitCleanupPrompt()
     navigate(`../instruments/${instrumentName}/new_session`)
   }
-  // Create Silence values and logic
+
+  // Turn alerts on/off - values and logic
+
   //calendar selection popup intialisation
   const {
     isOpen: isOpenCalendar,
@@ -192,31 +192,29 @@ export const Home = () => {
 
   const [existingEndTime, setExistingEndTime] = React.useState<Date | null>(
     null
-  ) //end time of longest existing silence
-  const [endTime, setEndTime] = React.useState<Date | null>(null) //end time of new silence
+  ) //longest silence endtime
+  const [endTime, setEndTime] = React.useState<Date | null>(null) //new silence endtime
   const [proposedEndTime, setProposedEndTime] = React.useState<Date | null>(
     null
-  ) //whilst date being chosen by user
-  const [activeSilence, setActiveSilence] = React.useState<Silence | null>(null)
+  ) //whilst date being chosen
 
-  //find longest active silence
-  const getActiveSilence = async () => {
+  //find longest existing silence and set existing end time
+  const checkExistingEndTime = async () => {
     const silence: Silence | null = await getLongestSilence(
       instrumentName ? instrumentName : ''
     )
     if (silence == null) {
-      setActiveSilence(null)
       setExistingEndTime(null)
       return null
     }
-    setActiveSilence(silence)
-    setExistingEndTime(new Date(silence.endsAt))
+    const existingEndsAt = new Date(silence.endsAt)
+    setExistingEndTime(existingEndsAt)
+    return existingEndsAt
   }
 
-  //on load, find longest active silence
+  //on load, find and set longest active silence end time
   useEffect(() => {
-    if (!sessionsData) return
-    getActiveSilence()
+    checkExistingEndTime()
   }, [])
 
   // Upon initialisation, zero out seconds field for calendar date/time picker
@@ -238,17 +236,18 @@ export const Home = () => {
     microscope: string | null,
     proposedEndTime: Date | null
   ) => {
-    if (microscope == null || proposedEndTime == null) return null
+    if (!microscope || !proposedEndTime) return null
     await createSilence(microscope, proposedEndTime)
-    getActiveSilence() //find which is now the longest silence
+    checkExistingEndTime() //find which is now the longest silence
     setEndTime(null)
   }
   const handleDeleteSilence = async (microscope: string | null) => {
     if (microscope == null) return null
     await deleteSilence(microscope)
-    getActiveSilence() //reset active silences to null
+    checkExistingEndTime() //reset active silences to null
     setEndTime(null)
   }
+
   // Page rendering logic below here
   if (isLoading) return <p>Loading sessions...</p>
   if (isError || !data) return <p>Failed to load sessions.</p>
@@ -461,7 +460,7 @@ export const Home = () => {
                 <VStack>
                   <VStack>
                     <Text>
-                      {activeSilence ? 'Alerts off until ' : ''}
+                      {existingEndTime ? 'Alerts off until ' : ''}
                       {existingEndTime
                         ? new Intl.DateTimeFormat('en-GB', {
                             timeZone: 'Europe/London',
@@ -480,10 +479,7 @@ export const Home = () => {
                     {existingEndTime ? (
                       <Button
                         variant="default"
-                        isActive={existingEndTime ? false : true}
-                        isDisabled={existingEndTime ? false : true}
                         onClick={() => {
-                          console.log('delete silence clicked' + instrumentName)
                           handleDeleteSilence(instrumentName)
                         }}
                       >

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -30,7 +30,6 @@ import {
   createSilence,
   deleteSilence,
   getLongestSilence,
-  getSilences,
   Silence,
 } from 'loaders/alertManager'
 import { getInstrumentConnectionStatus } from 'loaders/general'
@@ -184,6 +183,7 @@ export const Home = () => {
     navigate(`../instruments/${instrumentName}/new_session`)
   }
   // Create Silence values and logic
+  //calendar selection popup intialisation
   const {
     isOpen: isOpenCalendar,
     onOpen: onOpenCalendar,
@@ -196,9 +196,10 @@ export const Home = () => {
   const [endTime, setEndTime] = React.useState<Date | null>(null) //end time of new silence
   const [proposedEndTime, setProposedEndTime] = React.useState<Date | null>(
     null
-  ) //whilst date being picked
+  ) //whilst date being chosen by user
   const [activeSilence, setActiveSilence] = React.useState<Silence | null>(null)
-  //when page loads, find longest active silence. Find again when a new silence is addeds
+
+  //find longest active silence
   const getActiveSilence = async () => {
     const silence: Silence | null = await getLongestSilence(
       instrumentName ? instrumentName : ''
@@ -211,13 +212,14 @@ export const Home = () => {
     setActiveSilence(silence)
     setExistingEndTime(new Date(silence.endsAt))
   }
-  //find active silence on loads
+
+  //on load, find longest active silence
   useEffect(() => {
     if (!sessionsData) return
     getActiveSilence()
   }, [])
 
-  // Upon initialisation, zero out seconds field
+  // Upon initialisation, zero out seconds field for calendar date/time picker
   const defaultSilenceEndTime = (() => {
     let now = new Date()
     let timestamp = new Date(
@@ -238,7 +240,7 @@ export const Home = () => {
   ) => {
     if (microscope == null || proposedEndTime == null) return null
     await createSilence(microscope, proposedEndTime)
-    getActiveSilence() //find which is the longest silence
+    getActiveSilence() //find which is now the longest silence
     setEndTime(null)
   }
   const handleDeleteSilence = async (microscope: string | null) => {

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,3 +1,5 @@
+import { setSourceMapsEnabled } from 'process'
+
 import {
   Box,
   Button,
@@ -24,7 +26,12 @@ import {
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { InstrumentCard } from 'components/instrumentCard'
 import { SessionRow } from 'components/sessionRow'
-import { createSilence } from 'loaders/alertManager'
+import {
+  createSilence,
+  getLongestSilence,
+  getSilences,
+  Silence,
+} from 'loaders/alertManager'
 import { getInstrumentConnectionStatus } from 'loaders/general'
 import { sessionTokenCheck } from 'loaders/jwt'
 import { finaliseSession } from 'loaders/rsyncers'
@@ -182,10 +189,33 @@ export const Home = () => {
     onClose: onCloseCalendar,
   } = useDisclosure()
 
-  const [endTime, setEndTime] = React.useState<Date | null>(null)
+  const [existingEndTime, setExistingEndTime] = React.useState<Date | null>(
+    null
+  ) //end time of longest existing silence
+  const [endTime, setEndTime] = React.useState<Date | null>(null) //end time of new silence
   const [proposedEndTime, setProposedEndTime] = React.useState<Date | null>(
     null
+  ) //whilst date being picked
+  const [activeSilences, setActiveSilences] = React.useState<Silence | null>(
+    null
   )
+
+  useEffect(() => {
+    if (!sessionsData) return
+    const getActiveSilences = async () => {
+      const silences = await getLongestSilence(
+        instrumentName ? instrumentName : ''
+      )
+
+      if (silences == null) return false
+      setActiveSilences(silences)
+      const newEndTime = new Date(silences.endsAt)
+      console.log(newEndTime)
+      setExistingEndTime(newEndTime)
+    }
+    getActiveSilences()
+  }, [endTime])
+
   // Upon initialisation, zero out seconds field
   const defaultVisitEndTime = (() => {
     let now = new Date()
@@ -209,6 +239,7 @@ export const Home = () => {
     console.log(proposedEndTime)
     if (microscope == null || proposedEndTime == null) return null
     createSilence(microscope, proposedEndTime)
+    setEndTime(null)
   }
 
   // Page rendering logic below here
@@ -272,6 +303,7 @@ export const Home = () => {
         </Modal>
         <Modal isOpen={isOpenCalendar} onClose={onCloseCalendar} size={'xl'}>
           <ModalOverlay />
+          9T09:43:00.000Z
           <ModalContent>
             <ModalHeader>Select Silence End Time</ModalHeader>
             <ModalCloseButton />
@@ -413,13 +445,30 @@ export const Home = () => {
           </Box>
           {/* Right column showing instrument card */}
           <VStack>
-            <Box minW="400px" maxW="600px" flex="1" overflow="auto">
+            <Box minW="400px" maxW="600px" flex=":1" overflow="auto">
               <InstrumentCard />
             </Box>
-            <Card>
+            <Card width={'100%'}>
               <CardBody>
-                <HStack>
+                <VStack>
                   <VStack>
+                    <Text>{activeSilences ? 'Alerts Silenced Until' : ''}</Text>
+                    <Text>
+                      {existingEndTime
+                        ? new Intl.DateTimeFormat('en-GB', {
+                            timeZone: 'Europe/London',
+                            weekday: 'short',
+                            year: 'numeric',
+                            month: 'short',
+                            day: '2-digit',
+                            hour: '2-digit',
+                            minute: '2-digit',
+                            second: '2-digit',
+                            timeZoneName: 'short',
+                            hour12: false,
+                          }).format(existingEndTime)
+                        : ''}
+                    </Text>
                     <Text>Silence alerts until</Text>
                     <Text>
                       {endTime
@@ -438,25 +487,27 @@ export const Home = () => {
                         : 'NOT SET'}
                     </Text>
                   </VStack>
-                  <Tooltip label="Set end time for silence">
-                    <IconButton
-                      aria-label="calendar-for-end-time"
-                      onClick={() => onOpenCalendar()}
+                  <HStack>
+                    <Tooltip label="Set end time for silence">
+                      <IconButton
+                        aria-label="calendar-for-end-time"
+                        onClick={() => onOpenCalendar()}
+                      >
+                        <FaCalendar />
+                      </IconButton>
+                    </Tooltip>
+                    <Button
+                      variant="default"
+                      isDisabled={proposedEndTime ? false : true}
+                      onClick={() => {
+                        console.log(instrumentName)
+                        handleCreateSilence(instrumentName, proposedEndTime)
+                      }}
                     >
-                      <FaCalendar />
-                    </IconButton>
-                  </Tooltip>
-                  <Button
-                    variant="default"
-                    isDisabled={proposedEndTime ? false : true}
-                    onClick={() => {
-                      console.log(instrumentName)
-                      handleCreateSilence(instrumentName, proposedEndTime)
-                    }}
-                  >
-                    Silence Alerts
-                  </Button>
-                </HStack>
+                      Silence Alerts
+                    </Button>
+                  </HStack>
+                </VStack>
               </CardBody>
             </Card>
           </VStack>

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -39,7 +39,11 @@ import React, { useEffect } from 'react'
 import { FaCalendar } from 'react-icons/fa'
 import { useNavigate, useLoaderData } from 'react-router-dom'
 import { components } from 'schema/main'
-import { convertUKNaiveToUTC, convertUTCToUKNaive } from 'utils/generic'
+import {
+  convertUKNaiveToUTC,
+  convertUTCToUKNaive,
+  formatUTCISOToUKLocal,
+} from 'utils/generic'
 
 type Session = components['schemas']['Session']
 type ExpandedSession = Session & {
@@ -205,11 +209,12 @@ export const Home = () => {
     )
     if (silence == null) {
       setExistingEndTime(null)
-      return null
+      // return null
+    } else {
+      const existingEndsAt = new Date(silence.endsAt)
+      setExistingEndTime(existingEndsAt)
     }
-    const existingEndsAt = new Date(silence.endsAt)
-    setExistingEndTime(existingEndsAt)
-    return existingEndsAt
+    // return existingEndsAt
   }
 
   //on load, find and set longest active silence end time
@@ -459,23 +464,14 @@ export const Home = () => {
               <CardBody>
                 <VStack>
                   <VStack>
-                    <Text>
-                      {existingEndTime ? 'Alerts off until ' : ''}
-                      {existingEndTime
-                        ? new Intl.DateTimeFormat('en-GB', {
-                            timeZone: 'Europe/London',
-                            weekday: 'short',
-                            year: 'numeric',
-                            month: 'short',
-                            day: '2-digit',
-                            hour: '2-digit',
-                            minute: '2-digit',
-                            second: '2-digit',
-                            timeZoneName: 'short',
-                            hour12: false,
-                          }).format(existingEndTime)
-                        : ''}
-                    </Text>
+                    {existingEndTime ? (
+                      <Text>
+                        {'Alerts off until ' +
+                          formatUTCISOToUKLocal(existingEndTime.toString())}
+                      </Text>
+                    ) : (
+                      ''
+                    )}
                     {existingEndTime ? (
                       <Button
                         variant="default"
@@ -492,18 +488,7 @@ export const Home = () => {
                     <HStack>
                       <Text>
                         {endTime
-                          ? new Intl.DateTimeFormat('en-GB', {
-                              timeZone: 'Europe/London',
-                              weekday: 'short',
-                              year: 'numeric',
-                              month: 'short',
-                              day: '2-digit',
-                              hour: '2-digit',
-                              minute: '2-digit',
-                              second: '2-digit',
-                              timeZoneName: 'short',
-                              hour12: false,
-                            }).format(endTime)
+                          ? formatUTCISOToUKLocal(endTime.toString())
                           : 'NOT SET'}
                       </Text>
                       <Tooltip label="Set end time for silence">
@@ -516,7 +501,6 @@ export const Home = () => {
                       </Tooltip>
                     </HStack>
                   </VStack>
-
                   <HStack>
                     <Button
                       variant="default"

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -503,7 +503,6 @@ export const Home = () => {
                       variant="default"
                       isDisabled={endTime ? false : true}
                       onClick={() => {
-                        console.log(instrumentName)
                         handleCreateSilence(instrumentName, endTime)
                       }}
                     >


### PR DESCRIPTION
New card with buttons to turn off/on alerts on Home page below the instrument card. Turns off/on all alerts for that microscope. 
Calendar buttons and pop-up same as in NewSession.tsx

- 'Turn off alerts' button is always visible. If no end date/time is selected, it is deactivated. 
- Click the calendar button to select the date/time which the alerts will be off until. This opens a pop-up which allows an end date/time to be selected. This works the same as session end time. 
- If alerts are already off, 'Alerts off until [date, time]' is visible along with 'Turn on alerts' button.
