### PR TITLE
Remove skip existing processing switch 

### DIFF
--- a/src/routes/MultigridSetup.tsx
+++ b/src/routes/MultigridSetup.tsx
@@ -1,8 +1,6 @@
 import { ArrowForwardIcon } from '@chakra-ui/icons'
 import {
   Box,
-  FormControl,
-  FormLabel,
   GridItem,
   Heading,
   HStack,
@@ -10,7 +8,6 @@ import {
   Link,
   Select,
   Stack,
-  Switch,
   VStack,
 } from '@chakra-ui/react'
 import { SetupStepper } from 'components/setupStepper'
@@ -37,9 +34,6 @@ const MultigridSetup = () => {
     })
   const [selectedDirectory, setSelectedDirectory] =
     React.useState(initialDirectory)
-  const processByDefault = machineConfig
-    ? machineConfig.process_by_default
-    : true
   const [session, setSession] = React.useState<Session>()
 
   useEffect(() => {

--- a/src/routes/MultigridSetup.tsx
+++ b/src/routes/MultigridSetup.tsx
@@ -40,8 +40,6 @@ const MultigridSetup = () => {
   const processByDefault = machineConfig
     ? machineConfig.process_by_default
     : true
-  const [skipExistingProcessing, setSkipExistingProcessing] =
-    React.useState(!processByDefault)
   const [session, setSession] = React.useState<Session>()
 
   useEffect(() => {
@@ -63,7 +61,6 @@ const MultigridSetup = () => {
       await setupMultigridWatcher(
         {
           source: selectedDirectory,
-          skip_existing_processing: skipExistingProcessing,
         } as MultigridWatcherSpec,
         parseInt(sessid)
       )
@@ -125,16 +122,6 @@ const MultigridSetup = () => {
           >
             <VStack w="100%" spacing={0}>
               <Stack w="100%" spacing={5} py="0.8em">
-                <FormControl display="flex" alignItems="center">
-                  <FormLabel mb="0">Do not process existing data</FormLabel>
-                  <Switch
-                    id="skip-existing-processing"
-                    isChecked={!processByDefault}
-                    onChange={() => {
-                      setSkipExistingProcessing(!skipExistingProcessing)
-                    }}
-                  />
-                </FormControl>
                 <HStack>
                   <Select onChange={handleDirectorySelection}>
                     {machineConfig &&

--- a/src/routes/Session.tsx
+++ b/src/routes/Session.tsx
@@ -17,7 +17,6 @@ import {
   ModalBody,
   ModalCloseButton,
   Select,
-  Switch,
   Tooltip,
   VStack,
 } from '@chakra-ui/react'

--- a/src/routes/Session.tsx
+++ b/src/routes/Session.tsx
@@ -71,8 +71,6 @@ export const Session = () => {
   // Session information
   const [session, setSession] = React.useState<SessionSchema>()
   const [sessionActive, setSessionActive] = React.useState(false)
-  const [skipExistingProcessing, setSkipExistingProcessing] =
-    React.useState(false)
 
   // File transfer source information
   const [selectedDirectory, setSelectedDirectory] = React.useState('')
@@ -335,7 +333,6 @@ export const Session = () => {
       await setupMultigridWatcher(
         {
           source: selectedDirectory,
-          skip_existing_processing: skipExistingProcessing,
           destination_overrides: rsyncers
             ? Object.fromEntries(rsyncers.map((r) => [r.source, r.destination]))
             : {},
@@ -397,16 +394,6 @@ export const Session = () => {
                       </GridItem>
                     )}
                   </Select>
-                </HStack>
-                <HStack>
-                  <FormLabel mb="0">Do not process existing data</FormLabel>
-                  <Switch
-                    id="skip-existing-processing-reconnect"
-                    isChecked={false}
-                    onChange={() => {
-                      setSkipExistingProcessing(!skipExistingProcessing)
-                    }}
-                  />
                 </HStack>
               </VStack>
             </FormControl>

--- a/src/schema/main.ts
+++ b/src/schema/main.ts
@@ -1376,11 +1376,6 @@ export interface components {
        */
       source: string
       /**
-       * Skip Existing Processing
-       * @default false
-       */
-      skip_existing_processing?: boolean
-      /**
        * Destination Overrides
        * @default {}
        */


### PR DESCRIPTION
Remove skip existing processing switch here. The functionality is handled later where you can skip the input of processing parameters.