### PR TITLE
Check for the acquisition software associated with an instrument to determine if it needs processing parameters

### DIFF
--- a/src/routes/MultigridSetup.tsx
+++ b/src/routes/MultigridSetup.tsx
@@ -44,10 +44,11 @@ const MultigridSetup = () => {
   const handleDirectorySelection = (e: React.ChangeEvent<HTMLSelectElement>) =>
     setSelectedDirectory(e.target.value)
 
-  const acquisitionSoftware = ['epu', 'tomo']
+  // Check if this instrument requires user-provided processing parameters
+  const softwareNeedingParameters = ['epu', 'tomo']
   const hasProcessingParameters = machineConfig
     ? machineConfig.acquisition_software
-      ? !!acquisitionSoftware.some((software) =>
+      ? !!softwareNeedingParameters.some((software) =>
           machineConfig.acquisition_software?.includes(software)
         )
       : false

--- a/src/routes/MultigridSetup.tsx
+++ b/src/routes/MultigridSetup.tsx
@@ -44,9 +44,12 @@ const MultigridSetup = () => {
   const handleDirectorySelection = (e: React.ChangeEvent<HTMLSelectElement>) =>
     setSelectedDirectory(e.target.value)
 
-  const recipesDefined = machineConfig
-    ? machineConfig.recipes
-      ? Object.keys(machineConfig.recipes).length !== 0
+  const acquisitionSoftware = ['epu', 'tomo']
+  const hasProcessingParameters = machineConfig
+    ? machineConfig.acquisition_software
+      ? !!acquisitionSoftware.some((software) =>
+          machineConfig.acquisition_software?.includes(software)
+        )
       : false
     : false
 
@@ -58,7 +61,8 @@ const MultigridSetup = () => {
         } as MultigridWatcherSpec,
         parseInt(sessid)
       )
-      if (!recipesDefined) await startMultigridWatcher(parseInt(sessid))
+      if (!hasProcessingParameters)
+        await startMultigridWatcher(parseInt(sessid))
     }
   }
 
@@ -136,7 +140,7 @@ const MultigridSetup = () => {
                     _hover={{ textDecor: 'none' }}
                     as={LinkRouter}
                     to={
-                      recipesDefined
+                      hasProcessingParameters
                         ? `../new_session/parameters/${sessid}`
                         : `../sessions/${sessid}`
                     }

--- a/src/routes/Session.tsx
+++ b/src/routes/Session.tsx
@@ -166,9 +166,10 @@ export const Session = () => {
         config.gain_reference_directory.trim() !== ''
       )
     )
-    const acquisitionSoftware = ['epu', 'tomo']
+    // Check if this instrument requires user-provided processing parameters
+    const softwareNeedingParameters = ['epu', 'tomo']
     setHasProcessingParams(
-      !!acquisitionSoftware.some((software) =>
+      !!softwareNeedingParameters.some((software) =>
         config.acquisition_software?.includes(software)
       )
     )

--- a/src/routes/Session.tsx
+++ b/src/routes/Session.tsx
@@ -166,8 +166,11 @@ export const Session = () => {
         config.gain_reference_directory.trim() !== ''
       )
     )
+    const acquisitionSoftware = ['epu', 'tomo']
     setHasProcessingParams(
-      !!(config.recipes && Object.keys(config.recipes).length > 0)
+      !!acquisitionSoftware.some((software) =>
+        config.acquisition_software?.includes(software)
+      )
     )
   }
   useEffect(() => {


### PR DESCRIPTION
Previously, we checked to see if the `recipe` key in Murfey's `MachineConfig` Pydantic model was empty to redirect people to the processing parameters page. However, as we support more workflows, this is no longer a suitable check to use, as some workflows require recipes, but do not need user-provided processing parameters (e.g. the SXT worklow). Instead, the need for user-provided processing parameters is tied to the data types associated with an instrument. This is better reflected by the contents of the `acquisition_software` key in the `MachineConfig`.

This PR updates the pages that perform that redirect to the processing parameters page so that they check for the presence of `epu` and `tomo` in the `acquisition_software` key for a given instrument. If found, it will redirect the user to the processing parameters page.