### PR TITLE
Add logout logic

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,18 +1,23 @@
 import {
   Box,
-  Flex,
+  BoxProps,
+  Button,
+  Icon,
   IconButton,
   Image,
   Tooltip,
-  BoxProps,
-  Icon,
 } from '@chakra-ui/react'
 import { useQuery } from '@tanstack/react-query'
 import { getInstrumentConnectionStatus } from 'loaders/general'
 import React, { useEffect } from 'react'
-import { MdSignalWifi4Bar, MdOutlineSignalWifiBad } from 'react-icons/md'
+import {
+  MdSignalWifi4Bar,
+  MdOutlineSignalWifiBad,
+  MdLogout,
+} from 'react-icons/md'
 import { TbMicroscope, TbSnowflake, TbHomeCog } from 'react-icons/tb'
 import { useNavigate } from 'react-router-dom'
+import { logout } from 'utils/auth'
 
 export interface LinkDescriptor {
   label: string
@@ -60,75 +65,102 @@ export const Navbar = ({
 
   return (
     <Box position="sticky" top="0" zIndex={1} w="100%" h={12} {...props}>
-      <Flex
-        px={{
+      <Box
+        pl={{
           base: 4,
           md: 12,
         }}
+        pr={{
+          base: 4,
+        }}
         py={2}
-        gap={2}
-        direction="row"
+        display="flex"
+        flexDirection="row"
         alignItems="center"
+        justifyContent="space-between"
         bg="murfey.800"
       >
-        {logo ? (
-          <Box maxW={24}>
-            <Image src={logo} objectFit="contain" />
-          </Box>
-        ) : null}
-        <Tooltip label="Back to the Hub">
-          <IconButton
-            onClick={() => {
-              navigate(`/hub`)
-            }}
-            size="sm"
-            icon={
-              <>
-                <TbHomeCog />
-              </>
-            }
-            aria-label="Back to the Hub"
-            _hover={{ background: 'transparent', color: 'murfey.500' }}
-          />
-        </Tooltip>
-        {/* Add the instrument name as a URL query parameter to trigger a reload */}
-        <Tooltip label="Back to the microscope">
-          <IconButton
-            onClick={() => {
-              navigate(`/home`)
-            }}
-            size="sm"
-            icon={
-              <>
-                <TbSnowflake />
-                <TbMicroscope />
-              </>
-            }
-            aria-label="Back to the microscope"
-            _hover={{ background: 'transparent', color: 'murfey.500' }}
-          />
-        </Tooltip>
-        <Tooltip
-          label={
-            instrumentServerConnected
-              ? 'Connected to instrument server'
-              : 'No instrument server connection'
-          }
+        <Box
+          gap={2}
+          display="flex"
+          flexDirection="row"
+          alignItems="center"
+          justifyContent="flex-start"
         >
-          <span tabIndex={0}>
-            <Icon
-              as={
-                instrumentServerConnected
-                  ? MdSignalWifi4Bar
-                  : MdOutlineSignalWifiBad
+          {logo ? (
+            <Box maxW={24}>
+              <Image src={logo} objectFit="contain" />
+            </Box>
+          ) : null}
+          <Tooltip label="Back to the Hub">
+            <IconButton
+              onClick={() => {
+                navigate(`/hub`)
+              }}
+              size="sm"
+              icon={
+                <>
+                  <TbHomeCog />
+                </>
               }
-              color={instrumentServerConnected ? 'white' : 'red'}
-              mt={2}
-              ml={1}
+              aria-label="Back to the Hub"
+              _hover={{ background: 'transparent', color: 'murfey.500' }}
             />
-          </span>
-        </Tooltip>
-      </Flex>
+          </Tooltip>
+          {/* Add the instrument name as a URL query parameter to trigger a reload */}
+          <Tooltip label="Back to the microscope">
+            <IconButton
+              onClick={() => {
+                navigate(`/home`)
+              }}
+              size="sm"
+              icon={
+                <>
+                  <TbSnowflake />
+                  <TbMicroscope />
+                </>
+              }
+              aria-label="Back to the microscope"
+              _hover={{ background: 'transparent', color: 'murfey.500' }}
+            />
+          </Tooltip>
+          <Tooltip
+            label={
+              instrumentServerConnected
+                ? 'Connected to instrument server'
+                : 'No instrument server connection'
+            }
+          >
+            <span tabIndex={0}>
+              <Icon
+                as={
+                  instrumentServerConnected
+                    ? MdSignalWifi4Bar
+                    : MdOutlineSignalWifiBad
+                }
+                color={instrumentServerConnected ? 'white' : 'red'}
+                mt={2}
+                ml={1}
+              />
+            </span>
+          </Tooltip>
+        </Box>
+        <Box>
+          <Tooltip label="Sign out from Murfey">
+            <Button
+              aria-label="Sign out from Murfey"
+              onClick={() => {
+                logout()
+              }}
+              size="sm"
+              _hover={{ background: 'transparent', color: 'murfey.500' }}
+            >
+              {'Sign Out'}
+              <Icon as={MdLogout} boxSize={6} ml={2} />
+            </Button>
+          </Tooltip>
+        </Box>
+      </Box>
     </Box>
   )
 }

--- a/src/routes/Hub.tsx
+++ b/src/routes/Hub.tsx
@@ -1,7 +1,18 @@
-import { Card, Image, Text, Heading, Box } from '@chakra-ui/react'
+import {
+  Card,
+  Image,
+  Text,
+  Heading,
+  Box,
+  Button,
+  Icon,
+  Tooltip,
+} from '@chakra-ui/react'
 import { useEffect, useState } from 'react'
+import { MdLogout } from 'react-icons/md'
 import { TbMicroscope, TbSnowflake } from 'react-icons/tb'
 import { useLoaderData, useNavigate } from 'react-router-dom'
+import { logout } from 'utils/auth'
 
 const getUrl = (endpoint: string) => {
   return process.env.REACT_APP_HUB_ENDPOINT + endpoint
@@ -70,33 +81,60 @@ export const Hub = () => {
       {/* Title Bar */}
       <Box
         bg="murfey.700"
-        w="100%"
-        px={{
+        pl={{
           base: 8,
           md: 32,
         }}
+        pr={{
+          base: 8,
+        }}
         py={4}
+        w="100%"
         display="flex"
-        flexDirection="column"
-        alignItems="start"
-        justifyContent="start"
-        gap={2}
+        flexDirection="row"
+        alignItems="center"
+        justifyContent="space-between"
       >
-        {/* Show CryoEM icons on one row */}
+        {/* Title on the left */}
         <Box
-          display="inline-flex"
-          flexDirection="row"
-          justifyContent="center"
+          display="flex"
+          flexDirection="column"
           alignItems="start"
-          fontSize="3xl"
-          color="murfey.50"
+          justifyContent="start"
+          gap={2}
         >
-          <TbSnowflake />
-          <TbMicroscope />
+          {/* Show CryoEM icons on one row */}
+          <Box
+            display="inline-flex"
+            flexDirection="row"
+            justifyContent="center"
+            alignItems="start"
+            fontSize="3xl"
+            color="murfey.50"
+          >
+            <TbSnowflake />
+            <TbMicroscope />
+          </Box>
+          <Heading fontSize="3xl" w="100%" color="murfey.50">
+            Murfey Hub
+          </Heading>
         </Box>
-        <Heading fontSize="3xl" w="100%" color="murfey.50">
-          Murfey Hub
-        </Heading>
+        {/* Logout button on the right */}
+        <Box>
+          <Tooltip label="Sign out from Murfey">
+            <Button
+              aria-label="Sign out from Murfey"
+              onClick={() => {
+                logout()
+              }}
+              size="sm"
+              _hover={{ background: 'transparent', color: 'murfey.500' }}
+            >
+              {'Sign Out'}
+              <Icon as={MdLogout} boxSize={6} ml={2} />
+            </Button>
+          </Tooltip>
+        </Box>
       </Box>
       {/* Main body of Hub page showing the instruments */}
       {/* Render as a grid that overflows vertically */}

--- a/src/utils/auth.tsx
+++ b/src/utils/auth.tsx
@@ -1,0 +1,6 @@
+export const logout = () => {
+  // Clear all cookies, then redirect to the logout page
+  sessionStorage.clear()
+  localStorage.clear()
+  window.location.href = '/sign_out'
+}


### PR DESCRIPTION
Adds the minimal logic needed to facilitate signing users out of an externally applied authentication service. 

Buttons have been added to the `Hub` route and the `navbar` component that will navigate to the `/sign_out` URL path. There is no route in the app corresponding to that URL path, but it should be a redirect configured as part of the NGINX service used to run this app. This ensures that no security-related paths are hard-coded into this repo.