### PR TITLE
Select glob search strings when downloading upstream visits

### DIFF
--- a/src/components/upstreamVisitsCard.tsx
+++ b/src/components/upstreamVisitsCard.tsx
@@ -1,20 +1,39 @@
-import { Card, Box, Button, Heading } from '@chakra-ui/react'
+import {
+  Box,
+  Button,
+  Card,
+  Checkbox,
+  Heading,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  useDisclosure,
+} from '@chakra-ui/react'
 import { useQuery } from '@tanstack/react-query'
 import { getUpstreamVisits, upstreamDataDownloadRequest } from 'loaders/general'
 import { getInstrumentInfo } from 'loaders/general'
+import { getMachineConfigData } from 'loaders/machineConfig'
 import React, { useCallback, useEffect } from 'react'
 import { MdFileDownload } from 'react-icons/md'
+import { components } from 'schema/main'
+
+type MachineConfig = components['schemas']['MachineConfig']
 
 const InstrumentUpstreamVisitsCard = ({
   sessid,
   instrumentName,
   displayName,
   instrumentVisits,
+  searchStrings,
 }: {
   sessid: number
   instrumentName: string
   displayName: string
   instrumentVisits: Record<string, string>
+  searchStrings: string[]
 }) => {
   // Sort visits in ascending order
   const sortedVisits = Object.fromEntries(
@@ -31,6 +50,52 @@ const InstrumentUpstreamVisitsCard = ({
     })
   )
 
+  // Choose which search strings to perform the download with
+  const [visitName, setVisitName] = React.useState<string>('')
+  const [visitPath, setVisitPath] = React.useState<string>('')
+  const [selectedSearchStrings, setSelectedSearchStrings] = React.useState<
+    string[]
+  >([])
+  const {
+    isOpen: isOpenSelectSearchStrings,
+    onOpen: onOpenSelectSearchStrings,
+    onClose: onCloseSelectSearchStrings,
+  } = useDisclosure()
+
+  const toggleSelectedSearchStrings = (value: string) => {
+    setSelectedSearchStrings((prev) => {
+      if (prev.includes(value)) {
+        return prev.filter((v) => v !== value)
+      } else {
+        return [...prev, value]
+      }
+    })
+  }
+
+  const resetValues = () => {
+    // Set states back to default values
+    setVisitName('')
+    setVisitPath('')
+    setSelectedSearchStrings([])
+  }
+
+  const handleCloseSelectSearchStrings = () => {
+    resetValues()
+    onCloseSelectSearchStrings()
+  }
+
+  const handleUpstreamDataDownloadRequest = () => {
+    // Request upstream data download
+    upstreamDataDownloadRequest(
+      instrumentName,
+      sessid,
+      visitName,
+      visitPath,
+      searchStrings.filter((item) => selectedSearchStrings.includes(item))
+    )
+    handleCloseSelectSearchStrings()
+  }
+
   return (
     // Display upstream visits for a single instrument
     // Parameters to take: instrument name and upstream visits dict
@@ -43,6 +108,53 @@ const InstrumentUpstreamVisitsCard = ({
         borderColor: 'murfey.400',
       }}
     >
+      {/* Logic for pop-up components */}
+      <Modal
+        isOpen={isOpenSelectSearchStrings}
+        onClose={handleCloseSelectSearchStrings}
+      >
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Select search strings</ModalHeader>
+          <ModalBody>
+            Select the search strings you would like to use to find and download
+            files with
+            <Box
+              display="flex"
+              flexDirection="column"
+              alignItems="left"
+              justifyContent="start"
+            >
+              {searchStrings.map((item) => (
+                <Checkbox
+                  key={item}
+                  isChecked={selectedSearchStrings.includes(item)}
+                  onChange={() => toggleSelectedSearchStrings(item)}
+                  pl={2}
+                >
+                  {item}
+                </Checkbox>
+              ))}
+            </Box>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button
+              variant="ghost"
+              mr={3}
+              onClick={handleCloseSelectSearchStrings}
+            >
+              Close
+            </Button>
+            <Button
+              variant="default"
+              onClick={() => handleUpstreamDataDownloadRequest()}
+            >
+              Confirm
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
       <Box
         flex="1"
         display="flex"
@@ -72,14 +184,12 @@ const InstrumentUpstreamVisitsCard = ({
                     variant="default"
                     rightIcon={<MdFileDownload />}
                     cursor="pointer"
-                    onClick={() =>
-                      upstreamDataDownloadRequest(
-                        instrumentName,
-                        sessid,
-                        visitName,
-                        visitPath
-                      )
-                    }
+                    onClick={() => {
+                      setVisitName(visitName)
+                      setVisitPath(visitPath)
+                      setSelectedSearchStrings(searchStrings)
+                      onOpenSelectSearchStrings()
+                    }}
                     fontSize="md"
                   >
                     {visitName}
@@ -138,6 +248,22 @@ export const UpstreamVisitsCard = ({ sessid }: { sessid: number }) => {
       : instrumentName
   }
 
+  // Set up queryClient to get the current instrument's machine config
+  const { data: machineConfig } = useQuery<MachineConfig>({
+    queryKey: ['machineConfig'],
+    queryFn: getMachineConfigData,
+    staleTime: 60000,
+  })
+  const getUpstreamDataSearchStrings = (instrumentName: string) => {
+    // Early returns if the key or instrument doesn't exist
+    if (!machineConfig?.upstream_data_search_strings) return []
+    if (!machineConfig.upstream_data_search_strings[instrumentName]) return []
+    // Return filtered list of strings
+    return Array.from(
+      new Set(machineConfig.upstream_data_search_strings[instrumentName])
+    )
+  }
+
   return !!Object.keys(upstreamVisits).length && !!instrumentInfo ? (
     <Card
       w="100%"
@@ -171,6 +297,7 @@ export const UpstreamVisitsCard = ({ sessid }: { sessid: number }) => {
                 instrumentName={instrumentName}
                 displayName={getDisplayName(instrumentName)}
                 instrumentVisits={instrumentVisits}
+                searchStrings={getUpstreamDataSearchStrings(instrumentName)}
               />
             )
           }

--- a/src/loaders/general.tsx
+++ b/src/loaders/general.tsx
@@ -52,13 +52,15 @@ export const upstreamDataDownloadRequest = async (
   instrumentName: string,
   sessid: number,
   visitName: string,
-  visitPath: string
+  visitPath: string,
+  searchStrings: string[]
 ) => {
   const response = await client.post(
     `instrument_server/visits/${visitName}/sessions/${sessid}/upstream_file_data_request`,
     {
       upstream_instrument: instrumentName,
       upstream_visit_path: visitPath,
+      search_strings: searchStrings,
     }
   )
 

--- a/src/schema/main.ts
+++ b/src/schema/main.ts
@@ -1110,26 +1110,6 @@ export interface components {
     }
     /** MachineConfig */
     MachineConfig: {
-      /** Acquisition Software */
-      acquisition_software: string[]
-      /** Calibrations */
-      calibrations: {
-        [key: string]: {
-          [key: string]: Record<string, never> | number
-        }
-      }
-      /** Data Directories */
-      data_directories: string[]
-      /**
-       * Rsync Basepath
-       * Format: path
-       */
-      rsync_basepath: string
-      /**
-       * Default Model
-       * Format: path
-       */
-      default_model: string
       /**
        * Display Name
        * @default
@@ -1141,10 +1121,43 @@ export interface components {
        */
       instrument_name?: string
       /**
+       * Instrument Type
+       * @default
+       */
+      instrument_type?: string
+      /**
        * Image Path
        * Format: path
        */
       image_path?: string
+      /**
+       * Machine Override
+       * @default
+       */
+      machine_override?: string
+      /**
+       * Camera
+       * @default FALCON
+       */
+      camera?: string
+      /**
+       * Superres
+       * @default false
+       */
+      superres?: boolean
+      /**
+       * Calibrations
+       * @default {}
+       */
+      calibrations: {
+        [key: string]: {
+          [key: string]: Record<string, never> | number
+        }
+      }
+      /** Acquisition Software
+       * @default []
+       */
+      acquisition_software: string[]
       /**
        * Software Versions
        * @default {}
@@ -1152,6 +1165,181 @@ export interface components {
       software_versions?: {
         [key: string]: string
       }
+      /**
+       * Software Settings Output Directories
+       * @default {}
+       */
+      software_settings_output_directories?: {
+        [key: string]: string[]
+      }
+      /**
+       * Data Required Substrings
+       * @default {}
+       */
+      data_required_substrings?: {
+        [key: string]: {
+          [key: string]: string[]
+        }
+      }
+      /** Data Directories */
+      data_directories: string[]
+      /**
+       * Create Directories
+       * @default [
+       *   "atlas"
+       * ]
+       */
+      create_directories?: string[]
+      /**
+       * Analyse Created Directories
+       * @default []
+       */
+      analyse_created_directories?: string[]
+      /**
+       * Gain Reference Directory
+       * Format: path
+       * @default
+       */
+      gain_reference_directory?: string
+      /**
+       * Eer Fractionation File Template
+       * @default
+       */
+      eer_fractionation_file_template?: string
+      /**
+       * Single Data Directory
+       * @default false
+       */
+      single_data_directory?: boolean
+      /**
+       * Data Transfer Enabled
+       * @default true
+       */
+      data_transfer_enabled?: boolean
+      /**
+       * Substrings Blacklist
+       * @default {}
+       */
+      substrings_blacklist?: {
+        [key: string]: string[]
+      }
+      /**
+       * Mkdir Chmod
+       * @default 1512
+       */
+      mkdir_chmod?: number
+      /**
+       * Rsync Url
+       * @default
+       */
+      rsync_url?: string
+      /**
+       * Rsync Module
+       * @default
+       */
+      rsync_module?: string
+      /**
+       * Rsync Basepath
+       * Format: path
+       */
+      rsync_basepath: string
+      /**
+       * Rsync Chmod
+       * @default
+       */
+      rsync_chmod?: string
+      /**
+       * Allow Removal
+       * @default false
+       */
+      allow_removal?: boolean
+      /**
+       * Upstream Data Directories
+       * @default {}
+       */
+      upstream_data_directories?: {
+        [key: string]: string
+      }
+      /**
+       * Upstream Data Download Directory
+       * Format: path
+       * @default
+       */
+      upstream_data_download_directory?: string
+      /**
+       * Upstream Data Search Strings
+       * @default {}
+       */
+      upstream_data_search_strings?: {
+        [key: string]: string[]
+      }
+      /**
+       * Upstream Data Tiff Locations
+       * @default [
+       *   "processed"
+       * ]
+       */
+      upstream_data_tiff_locations?: string[]
+      /**
+       * Processing Enabled
+       * @default true
+       */
+      processing_enabled?: boolean
+      /**
+       * Process By Default
+       * @default true
+       */
+      process_by_default?: boolean
+      /**
+       * Gain Directory Name
+       * @default processing
+       */
+      gain_directory_name?: string
+      /**
+       * Process Multiple Datasets
+       * @default true
+       */
+      process_multiple_datasets?: boolean
+      /**
+       * Processed Directory Name
+       * @default processed
+       */
+      processed_directory_name?: string
+      /**
+       * Processed Extra Directory
+       * @default
+       */
+      processed_extra_directory?: string
+      /**
+       * Recipes
+       * @default {
+       *   "em-spa-bfactor": "em-spa-bfactor",
+       *   "em-spa-class2d": "em-spa-class2d",
+       *   "em-spa-class3d": "em-spa-class3d",
+       *   "em-spa-preprocess": "em-spa-preprocess",
+       *   "em-spa-refine": "em-spa-refine",
+       *   "em-tomo-preprocess": "em-tomo-preprocess",
+       *   "em-tomo-align": "em-tomo-align"
+       * }
+       */
+      recipes?: {
+        [key: string]: string
+      }
+      /**
+       * Default Model
+       * Format: path
+       */
+      default_model: string
+      /**
+       * Picking Model Search Directory
+       * @default processing
+       */
+      picking_model_search_directory?: string
+      /**
+       * Initial Model Search Directory
+       * @default processing/initial_model
+       */
+      initial_model_search_directory?: string
       /**
        * External Executables
        * @default {}
@@ -1174,92 +1362,6 @@ export interface components {
         [key: string]: string
       }
       /**
-       * Rsync Module
-       * @default
-       */
-      rsync_module?: string
-      /**
-       * Create Directories
-       * @default [
-       *   "atlas"
-       * ]
-       */
-      create_directories?: string[]
-      /**
-       * Analyse Created Directories
-       * @default []
-       */
-      analyse_created_directories?: string[]
-      /**
-       * Gain Reference Directory
-       * Format: path
-       */
-      gain_reference_directory?: string
-      /**
-       * Eer Fractionation File Template
-       * @default
-       */
-      eer_fractionation_file_template?: string
-      /**
-       * Processed Directory Name
-       * @default processed
-       */
-      processed_directory_name?: string
-      /**
-       * Gain Directory Name
-       * @default processing
-       */
-      gain_directory_name?: string
-      /**
-       * Node Creator Queue
-       * @default node_creator
-       */
-      node_creator_queue?: string
-      /**
-       * Superres
-       * @default false
-       */
-      superres?: boolean
-      /**
-       * Camera
-       * @default FALCON
-       */
-      camera?: string
-      /**
-       * Data Required Substrings
-       * @default {}
-       */
-      data_required_substrings?: {
-        [key: string]: {
-          [key: string]: string[]
-        }
-      }
-      /**
-       * Allow Removal
-       * @default false
-       */
-      allow_removal?: boolean
-      /**
-       * Data Transfer Enabled
-       * @default true
-       */
-      data_transfer_enabled?: boolean
-      /**
-       * Processing Enabled
-       * @default true
-       */
-      processing_enabled?: boolean
-      /**
-       * Machine Override
-       * @default
-       */
-      machine_override?: string
-      /**
-       * Processed Extra Directory
-       * @default
-       */
-      processed_extra_directory?: string
-      /**
        * Plugin Packages
        * @default {}
        */
@@ -1267,94 +1369,45 @@ export interface components {
         [key: string]: string
       }
       /**
-       * Software Settings Output Directories
-       * @default {}
-       */
-      software_settings_output_directories?: {
-        [key: string]: string[]
-      }
-      /**
-       * Process By Default
-       * @default true
-       */
-      process_by_default?: boolean
-      /**
-       * Recipes
-       * @default {
-       *   "em-spa-bfactor": "em-spa-bfactor",
-       *   "em-spa-class2d": "em-spa-class2d",
-       *   "em-spa-class3d": "em-spa-class3d",
-       *   "em-spa-preprocess": "em-spa-preprocess",
-       *   "em-spa-refine": "em-spa-refine",
-       *   "em-tomo-preprocess": "em-tomo-preprocess",
-       *   "em-tomo-align": "em-tomo-align"
-       * }
-       */
-      recipes?: {
-        [key: string]: string
-      }
-      /**
-       * Upstream Data Directories
-       * @default []
-       */
-      upstream_data_directories?: string[]
-      /**
-       * Upstream Data Download Directory
+       * Security Configuration Path
        * Format: path
        */
-      upstream_data_download_directory?: string
-      /**
-       * Upstream Data Tiff Locations
-       * @default [
-       *   "processed"
-       * ]
-       */
-      upstream_data_tiff_locations?: string[]
-      /**
-       * Model Search Directory
-       * @default processing
-       */
-      model_search_directory?: string
-      /**
-       * Initial Model Search Directory
-       * @default processing/initial_model
-       */
-      initial_model_search_directory?: string
-      /**
-       * Failure Queue
-       * @default
-       */
-      failure_queue?: string
-      /**
-       * Instrument Server Url
-       * @default http://localhost:8001
-       */
-      instrument_server_url?: string
-      /**
-       * Frontend Url
-       * @default http://localhost:3000
-       */
-      frontend_url?: string
+      security_configuration_path?: string
       /**
        * Murfey Url
        * @default http://localhost:8000
        */
       murfey_url?: string
       /**
-       * Rsync Url
+       * Frontend Url
+       * @default http://localhost:3000
+       */
+      frontend_url?: string
+      /**
+       * Instrument Server Url
+       * @default http://localhost:8001
+       */
+      instrument_server_url?: string
+      /**
+       * Smartem Api Url
        * @default
        */
-      rsync_url?: string
+      smartem_api_url?: string
       /**
-       * Security Configuration Path
-       * Format: path
-       */
-      security_configuration_path?: string
-      /**
-       * Auth Url
+       * Alert Manager Url
        * @default
        */
-      auth_url?: string
+      alertmanager_url?: string
+      /**
+       * Failure Queue
+       * @default
+       */
+      failure_queue?: string
+      /**
+       * Node Creator Queue
+       * @default node_creator
+       */
+      node_creator_queue?: string
       /**
        * Notifications Queue
        * @default pato_notification


### PR DESCRIPTION
We previously introduced the `UpstreamVisitsCard` component, which enabled users to trigger the download of data from past visits belonging to the same proposal. This process involved performing glob searches in the backend using a pre-configured list of search patterns. There was no option to skip search patterns that are not relevant to the user's current needs.

This PR updates the `UpstreamVisitsCard` component so that upon clicking on a visit to download, users can now view the search strings configured for that visit type, and select only the ones they want to use to find and download files with. The MachineConfig schema was also manually updated to include some of the newer keys introduced on the backend side.

This PR is tied to https://github.com/DiamondLightSource/python-murfey/pull/835 . Both should be rolled out in tandem.