### PR TITLE
Fixed dose per frame units

### DIFF
--- a/src/components/forms.tsx
+++ b/src/components/forms.tsx
@@ -76,7 +76,7 @@ const SpaForm = (submissionCallback: (arg0: any) => void) => {
         <FormControl>
           <VStack align="start" spacing={10} width="100%" display="flex">
             <VStack align="start" width="100%" display="flex">
-              <FormLabel>{'Dose per frame [\u212B / pixel]'}</FormLabel>
+              <FormLabel>{'Dose per frame [e\u207B / \u212B\u00B2]'}</FormLabel>
               <Input defaultValue="1" name="dose" />
             </VStack>
             <VStack align="start" width="100%" display="flex">
@@ -171,7 +171,7 @@ const TomoForm = (submissionCallback: (arg0: any) => void) => {
         <FormControl>
           <VStack align="start" spacing={10} width="100%" display="flex">
             <VStack align="start" width="100%" display="flex">
-              <FormLabel>{'Dose per frame [\u212B / pixel]'}</FormLabel>
+              <FormLabel>{'Dose per frame [e\u207B / \u212B\u00B2]'}</FormLabel>
               <Input defaultValue="0.5" name="dose" />
             </VStack>
             <VStack align="start" width="100%" display="flex">

--- a/src/routes/ProcessingParameters.tsx
+++ b/src/routes/ProcessingParameters.tsx
@@ -33,7 +33,7 @@ type ProcessingTable = {
 const nameLabelMap: Map<string, string> = new Map([
   ['pj_id', 'Processing Job ID'],
   ['angpix', 'Pixel Size [m]'],
-  ['dose_per_frame', 'Dose per frame [e- / \u212B]'],
+  ['dose_per_frame', 'Dose per frame [e\u207B / \u212B\u00B2]'],
   ['gain_ref', 'Gain Reference'],
   ['voltage', 'Voltage [kV]'],
   ['motion_corr_binning', 'Motion correction binning factor'],

--- a/src/routes/SessionParameters.tsx
+++ b/src/routes/SessionParameters.tsx
@@ -38,7 +38,7 @@ type ProcessingTable = {
 }
 
 const nameLabelMap: Map<string, string> = new Map([
-  ['dose_per_frame', 'Dose per frame [e- / \u212B]'],
+  ['dose_per_frame', 'Dose per frame [e\u207B / \u212B\u00B2]'],
   ['gain_ref', 'Gain Reference'],
   ['symmetry', 'Symmetry'],
   ['eer_fractionation_file', 'EER fractionation file (for motion correction)'],


### PR DESCRIPTION
The "Dose per frame" units were set incorrectly. They should all be electrons per square Angstrom.